### PR TITLE
Allow access to the entry (and its expiration) via get()

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -135,6 +135,13 @@ pub struct CacheEntryReadGuard<'a, V> {
     pub(crate) marker: PhantomData<&'a CacheEntry<V>>,
 }
 
+impl<'a, V> CacheEntryReadGuard<'a, V> {
+    /// Retrieve the entry value and its associated expiration.
+    pub fn entry(&self) -> &CacheEntry<V> {
+        unsafe { &*self.entry }
+    }
+}
+
 impl<'a, V> Deref for CacheEntryReadGuard<'a, V> {
     type Target = V;
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -25,7 +25,11 @@ async fn test_cache_update_operations() {
 
     cache.insert_untracked(1, 1).await;
 
+    // Direct value access
     assert_eq!(*cache.get(&1).await.unwrap(), 1);
+    // Entry info access
+    assert_eq!(cache.get(&1).await.unwrap().entry().is_expired(), false);
+    assert_eq!(cache.get(&1).await.unwrap().entry().value(), &1);
 
     cache
         .update(&1, |value| {
@@ -33,5 +37,9 @@ async fn test_cache_update_operations() {
         })
         .await;
 
+    // Direct value access
     assert_eq!(*cache.get(&1).await.unwrap(), 5);
+    // Entry info access
+    assert_eq!(cache.get(&1).await.unwrap().entry().is_expired(), false);
+    assert_eq!(cache.get(&1).await.unwrap().entry().value(), &5);
 }


### PR DESCRIPTION
Adds an `entry()` accessor, which operates in parallel to the existing `deref()` access to the underlying value.

(Resolves #6)