### PR TITLE
Make expirations mutable

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -300,6 +300,16 @@ where
             f(entry.value_mut());
         }
     }
+
+    pub async fn update_expiration<F>(&self, k: &K, f: F)
+    where
+        F: FnOnce(&mut CacheExpiration),
+    {
+        let mut guard = self.store.write().await;
+        if let Some(entry) = guard.get_mut(k).and_then(|entry| unpack!(entry)) {
+            f(entry.expiration_mut());
+        }
+    }
 }
 
 /// Default implementation.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -302,13 +302,13 @@ where
     }
 
     /// Updates the expiration of an entry in place
-    pub async fn update_expiration<F>(&self, k: &K, f: F)
+    pub async fn set_expiration<E>(&self, k: &K, e: E)
     where
-        F: FnOnce(&mut CacheExpiration),
+        E: Into<CacheExpiration>,
     {
         let mut guard = self.store.write().await;
         if let Some(entry) = guard.get_mut(k).and_then(|entry| unpack!(entry)) {
-            f(entry.expiration_mut());
+            entry.set_expiration(e.into());
         }
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -301,6 +301,7 @@ where
         }
     }
 
+    /// Updates the expiration of an entry in place
     pub async fn update_expiration<F>(&self, k: &K, f: F)
     where
         F: FnOnce(&mut CacheExpiration),

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -301,7 +301,7 @@ where
         }
     }
 
-    /// Updates the expiration of an entry in place
+    /// Sets the expiration of an entry
     pub async fn set_expiration<E>(&self, k: &K, e: E)
     where
         E: Into<CacheExpiration>,

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -30,6 +30,11 @@ impl<V> CacheEntry<V> {
         &self.expiration
     }
 
+    /// Retrieve the mutable internal expiration
+    pub fn expiration_mut(&mut self) -> &mut CacheExpiration {
+        &mut self.expiration
+    }
+
     /// Retrieve the internal value.
     pub fn value(&self) -> &V {
         &self.value

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -30,9 +30,9 @@ impl<V> CacheEntry<V> {
         &self.expiration
     }
 
-    /// Retrieve the mutable internal expiration
-    pub fn expiration_mut(&mut self) -> &mut CacheExpiration {
-        &mut self.expiration
+    /// Set the internal expiration
+    pub fn set_expiration(&mut self, expiration: CacheExpiration) {
+        self.expiration = expiration;
     }
 
     /// Retrieve the internal value.


### PR DESCRIPTION
Adds the ability to change an entry's expiration without removing and re-adding the entry. I tried to follow the existing API patterns as closely as possible.

I plan to use this in a user session context; that is, I want to be able to push back the expiration instant whenever the session data is accessed.