### PR TITLE
Include README as a crate level documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ improvements and I'll get to them as soon as possible :).
 ### Getting Started
 
 This crate is available on [crates.io](https://crates.io/crates/retainer). The
-easiest way to use it is to add an entry to your `Cargo.toml` defining the dependency:
+easiest way to use it is to add an entry to your `Cargo.toml` defining the dependency
+using `cargo add`:
 
-```toml
-[dependencies]
-retainer = "0.3"
+```sh
+$ cargo add retainer
 ```
 
 ### Basic Usage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,4 @@
-//! Very small caching utility with async locking support.
-//!
-//! All interaction in this crate will be done through the `Cache` type,
-//! so please see the the `cache` module for further instructions.
-#![doc(html_root_url = "https://docs.rs/retainer/0.3.0")]
+#![doc = include_str!("../README.md")]
 
 // exposed modules
 pub mod cache;


### PR DESCRIPTION
Additionally suggest `cargo add` which will always resolve to the latest version of `retainer`.

Including README this way will make the README example run during unit testing phase.

I've also removed `#![doc(html_root_url = "https://docs.rs/retainer/0.3.0")]` since it also embeds the crate version and [from my casual skim](https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#html_root_url) it's not *that* useful but I'm open to be persuaded the other way :)

Fixes: https://github.com/whitfin/retainer/issues/11

Btw, I'm using your crate [for simple PIN-cache](https://github.com/wiktor-k/ssh-agent-lib/pull/56/files#diff-4e7fb2261df3c70042fe7740d724183d99f9fce4ec1787b84c0073d08689f55dR42) and it's working great since I can have, in the same code, [non-expiring PINs](https://github.com/wiktor-k/ssh-agent-lib/pull/56/files#diff-4e7fb2261df3c70042fe7740d724183d99f9fce4ec1787b84c0073d08689f55dR164) as well as [user configurable expiration](https://github.com/wiktor-k/ssh-agent-lib/pull/56/files#diff-4e7fb2261df3c70042fe7740d724183d99f9fce4ec1787b84c0073d08689f55dR178-R184). Really nice API, thanks! :bow: 

Have a nice day! :wave: 